### PR TITLE
Fix unmapping when coalescing forward

### DIFF
--- a/dlmalloc_nonreuse.c
+++ b/dlmalloc_nonreuse.c
@@ -3585,7 +3585,7 @@ dlfree(void* mem) {
                  * next chunk.
                  */
                 set_cunmapped(p);
-                unmap_end = __builtin_align_up(next, mparams.page_size);
+                unmap_end = __builtin_align_up(chunk2mem(next), mparams.page_size);
               }
 #endif
             }


### PR DESCRIPTION
If the chunk header of an unmapped region was page-aligned, then the
ajoining previous region to be unmapped was not considered to include
the chunk header.